### PR TITLE
docs(README.md): fixes argument documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use **linky** pipe with **[innerHTML]** (or outerHTML, depends on you) binding t
 
 You can pass any [autolinker option](https://github.com/gregjacobs/Autolinker.js#options) as a second pipe argument. For ex.:
 
-`<span [innerHTML]="myText | linky:{newWindow: false}"></span>`
+`<span [innerHTML]="myText | linky:[{newWindow: false, twitter: false}]"></span>`
 
 ## License
 MIT


### PR DESCRIPTION
The arguments have to be passed as an array since they're accessed via `args[0]`: https://github.com/dzonatan/angular2-linky/blob/27506e6205b7c041bf3675cb2823b0ac29424141/linky-pipe.ts#L7
